### PR TITLE
Fix CAM training + update CAM visualization code

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -489,15 +489,15 @@ class multilabel_classifier():
         """Train the 'CAM-based' model for one epoch"""
 
         def returnCAM(feature_conv, weight_softmax, class_idx, device):
-            bz, nc, h, w = feature_conv.shape
+            nc, h, w = feature_conv.shape # (hidden_size, height, width)
             output_cam = torch.Tensor(0, 7, 7).to(device=device)
             for idx in class_idx:
                 cam = torch.mm(weight_softmax[idx].unsqueeze(0), feature_conv.reshape((nc, h*w)))
                 cam = cam.reshape(h, w)
                 cam = cam - cam.min()
-                cam_img = cam / cam.max()
-                output_cam = torch.cat((output_cam, cam_img.unsqueeze(0)), 0)
-            return output_cam
+                cam_img = cam / cam.max() # (h, w)
+                output_cam = torch.cat((output_cam, cam_img.unsqueeze(0)), dim=0)
+            return output_cam # (2, height, width) dim0 is 2 because idx = [b, c]
 
         pretrained_net.model = pretrained_net.model.to(device=self.device, dtype=self.dtype)
         pretrained_net.model.eval()
@@ -506,9 +506,9 @@ class multilabel_classifier():
         self.model.train()
 
         classifier_params = list(self.model.parameters())
-        classifier_softmax_weight = classifier_params[-2].squeeze(0)
+        classifier_softmax_weight = classifier_params[-2].squeeze(0).to(torch.device('cuda:1'))
         pretrained_params = list(pretrained_net.model.parameters())
-        pretrained_softmax_weight = np.squeeze(pretrained_params[-2])
+        pretrained_softmax_weight = np.squeeze(pretrained_params[-2]).to(torch.device('cuda:1'))
 
         # Loop over batches
         loss_list = []
@@ -529,32 +529,40 @@ class multilabel_classifier():
             # Get CAM from the current network
             classifier_features.clear()
             outputs = self.forward(images) # where the length of classifier_features increases
+            outputs.cpu()
 
             # In multi-GPU training, the hook outputs a list of outputs from each GPU, 
             # so we need to recombine them
-            classifier_feature_outputs = [x.to(device=self.device, dtype=self.dtype) for x in classifier_features]
-            classifier_feature_outputs = torch.cat(classifier_feature_outputs, dim=0).to(device=self.device, dtype=self.dtype)
+            classifier_features_all = [x.to(device=torch.device('cpu'), dtype=torch.float32) for x in classifier_features]
+            classifier_features_all = torch.cat(classifier_features_all, dim=0)
+            biased_classifier_features = classifier_features_all[cooccur].to(device=torch.device('cuda:1'), dtype=self.dtype)
 
-            CAMs = torch.Tensor(0, 2, 7, 7).to(device=self.device)
+            CAMs = torch.Tensor(0, 2, 7, 7).to(device=torch.device('cuda:1'))
             for k in range(len(cooccur)):
-                CAM = returnCAM(classifier_feature_outputs[cooccur[k]].unsqueeze(0), classifier_softmax_weight, cooccur_classes[k], self.device)
+                CAM = returnCAM(biased_classifier_features[k], classifier_softmax_weight, cooccur_classes[k], torch.device('cuda:1'))
                 CAMs = torch.cat((CAMs, CAM.unsqueeze(0)), 0)
+            del biased_classifier_features
+            CAMs = CAMs.to(device=torch.device('cpu'))
 
             # Get CAM from the pre-trained network
             pretrained_features.clear()
-            _ = pretrained_net.model(images)
+            pretrained_net.model(images)
 
             # In multi-GPU training, the hook outputs a list of outputs from each GPU,
             # so we need to recombine them
-            pretrained_feature_outputs = [x.to(device=self.device, dtype=self.dtype) for x in pretrained_features]
-            pretrained_feature_outputs = torch.cat(pretrained_feature_outputs, dim=0).to(device=self.device, dtype=self.dtype)
+            pretrained_features_all = [x.to(device=torch.device('cpu'), dtype=torch.float32) for x in pretrained_features]
+            pretrained_features_all = torch.cat(pretrained_features_all, dim=0)
+            biased_pretrained_features = pretrained_features_all[cooccur].to(device=torch.device('cuda:1'), dtype=self.dtype)
 
-            CAMs_pretrained = torch.Tensor(0, 2, 7, 7).to(self.device)
+            CAMs_pretrained = torch.Tensor(0, 2, 7, 7).to(torch.device('cuda:1'))
             for k in range(len(cooccur)):
-                CAM_pretrained = returnCAM(pretrained_feature_outputs[cooccur[k]].unsqueeze(0), pretrained_softmax_weight, cooccur_classes[k], self.device)
+                CAM_pretrained = returnCAM(biased_pretrained_features[k], pretrained_softmax_weight, cooccur_classes[k], torch.device('cuda:1'))
                 CAMs_pretrained = torch.cat((CAMs_pretrained, CAM_pretrained.unsqueeze(0)), 0)
+            del biased_pretrained_features
+            CAMs_pretrained = CAMs_pretrained.to(device=torch.device('cpu'))
 
             # Compute and update with the loss
+            outputs = outputs.to(device=self.device, dtype=self.dtype)
             self.optimizer.zero_grad()
             l_o = (CAMs[:,0] * CAMs[:,1]).mean()
             l_r = torch.abs(CAMs - CAMs_pretrained).mean()
@@ -563,6 +571,11 @@ class multilabel_classifier():
             loss = 0.1*l_o + 0.01*l_r + l_bce
             loss.backward()
             self.optimizer.step()
+            
+            # Clean up
+            del outputs
+            del CAMs
+            del CAMs_pretrained
 
             loss_list.append(loss.item())
             if self.print_freq and (i % self.print_freq == 0):

--- a/evaluate.py
+++ b/evaluate.py
@@ -29,7 +29,7 @@ def main():
     print('\n', arg, '\n')
 
     # Load utility files
-    biased_classes_mapped = pickle.load(open('/n/fs/context-scr/{}/our_biased_classes_mapped.pkl'.format(arg['dataset']), 'rb'))
+    biased_classes_mapped = pickle.load(open('/n/fs/context-scr/{}/biased_classes_mapped.pkl'.format(arg['dataset']), 'rb'))
     if arg['dataset'] == 'COCOStuff':
         unbiased_classes_mapped = pickle.load(open('/n/fs/context-scr/{}/unbiased_classes_mapped.pkl'.format(arg['dataset']), 'rb'))
     humanlabels_to_onehot = pickle.load(open('/n/fs/context-scr/{}/humanlabels_to_onehot.pkl'.format(arg['dataset']), 'rb'))

--- a/evaluate.py
+++ b/evaluate.py
@@ -93,7 +93,6 @@ def main():
         # Categorize the images into co-occur/exclusive/other
         if splitbiased:
             cooccur = (labels_list[:,arg['nclasses']+k-20]==1)
-            print(len(np.where(cooccur==True)[0]))
             exclusive = (labels_list[:,b]==1)
         else:
             cooccur = (labels_list[:,b]==1) & (labels_list[:,c]==1)

--- a/evaluate.py
+++ b/evaluate.py
@@ -14,7 +14,8 @@ def main():
     parser.add_argument('--model', type=str)
     parser.add_argument('--modelpath', type=str, default=None)
     parser.add_argument('--pretrainedpath', type=str, default=None)
-    parser.add_argument('--labels', type=str, default='/n/fs/context-scr/COCOStuff/labels_val.pkl')
+    parser.add_argument('--labels_test', type=str, default='/n/fs/context-scr/COCOStuff/labels_val.pkl')
+    parser.add_argument('--labels_train', type=str, default=None)
     parser.add_argument('--batchsize', type=int, default=170)
     parser.add_argument('--nclasses', type=int, default=171)
     parser.add_argument('--hs', type=int, default=2048)
@@ -28,17 +29,17 @@ def main():
     print('\n', arg, '\n')
 
     # Load utility files
-    biased_classes_mapped = pickle.load(open('/n/fs/context-scr/{}/biased_classes_mapped.pkl'.format(arg['dataset']), 'rb'))
+    biased_classes_mapped = pickle.load(open('/n/fs/context-scr/{}/our_biased_classes_mapped.pkl'.format(arg['dataset']), 'rb'))
     if arg['dataset'] == 'COCOStuff':
         unbiased_classes_mapped = pickle.load(open('/n/fs/context-scr/{}/unbiased_classes_mapped.pkl'.format(arg['dataset']), 'rb'))
     humanlabels_to_onehot = pickle.load(open('/n/fs/context-scr/{}/humanlabels_to_onehot.pkl'.format(arg['dataset']), 'rb'))
     onehot_to_humanlabels = dict((y,x) for x,y in humanlabels_to_onehot.items())
 
     # Create dataloader
-    testset = create_dataset(arg['dataset'], arg['labels'], biased_classes_mapped, B=arg['batchsize'], train=False, splitbiased=splitbiased)
+    testset = create_dataset(arg['dataset'], arg['labels_test'], biased_classes_mapped, B=arg['batchsize'], train=False, splitbiased=splitbiased)
 
     # Load model
-    classifier = multilabel_classifier(arg['device'], arg['dtype'], arg['nclasses'], arg['modelpath'], hidden_size=arg['hs'])
+    classifier = multilabel_classifier(arg['device'], arg['dtype'], arg['nclasses'], arg['modelpath'], hidden_size=arg['hs'], attribdecorr=(arg['model']=='attribdecorr'))
     if arg['model'] == 'classbalancing':
         weight = calculate_classbalancing_weight(arg['labels_train'], arg['nclasses'], biased_classes_mapped, beta=0.99)
         weight = weight.to(arg['device'])

--- a/get_cams.py
+++ b/get_cams.py
@@ -17,6 +17,12 @@ from load_data import *
 ###
 # Referenced from:
 # https://github.com/jacobgil/pytorch-grad-cam/blob/master/gradcam.py
+#
+# Example usage:
+# python get_cams.py --modelpath $MODELPATH --img_ids 535811 430054 554674
+#
+# --modelpath: path to the model to visualize
+# --img_ids: COCOStuff image IDs (use the Explore tool on the COCO dataset website)
 ###
 
 def get_heatmap(CAM_map, img):

--- a/get_cams.py
+++ b/get_cams.py
@@ -4,6 +4,7 @@ import torch
 import sys
 import os
 import cv2
+import argparse
 import matplotlib.pyplot as plt
 import torchvision.transforms as T
 
@@ -27,45 +28,26 @@ def get_heatmap(CAM_map, img):
     heatmap = np.uint8(255 * heatmap)
     return heatmap
 
-def returnCAM(feature_conv, weight_softmax, class_idx):
+def returnCAM(feature_conv, weight_softmax, class_idx, device):
     bz, nc, h, w = feature_conv.shape
-    output_cam = torch.Tensor(0, 7, 7)#.cuda()
+    output_cam = torch.Tensor(0, 7, 7).to(device=device)
     for idx in class_idx:
         cam = torch.mm(weight_softmax[idx].unsqueeze(0), feature_conv.reshape((nc, h*w)))
         cam = cam.reshape(h, w)
         cam = cam - cam.min()
         cam_img = cam / cam.max()
         output_cam = torch.cat((output_cam, cam_img.unsqueeze(0)), 0)
-
     return output_cam
 
 def main():
-    dataset = sys.argv[1]
-
-    # Open image
-    img_path = '/n/fs/visualai-scr/Data/Coco/2014data/train2014/COCO_train2014_000000002560.jpg'
-    img_name = img_path.split('/')[-1][:-4]
-    original_img = Image.open(img_path).convert('RGB')
-
-    outdir = '{}/CAMs/'.format(dataset)
-    if not os.path.exists(outdir):
-        os.makedirs(outdir)
-    print('Saving CAMs in directory {}'.format(outdir))
-
-    # Get image class labels
-    img_labels = pickle.load(open('/n/fs/context-scr/{}/labels_train.pkl'.format(dataset), 'rb'))
-    if img_path in img_labels:
-        class_labels = img_labels[img_path].type('torch.ByteTensor') # torch.cuda.ByteTensor
-    else:
-        img_labels = pickle.load(open('/n/fs/context-scr/{}/labels_val.pkl'.format(dataset), 'rb'))
-        if img_path in img_labels:
-            class_labels = img_labels[img_path].type('torch.ByteTensor') # torch.cuda.ByteTensor
-        else:
-            print('No labels found for image {}'.format(img_path))
-            class_labels = torch.zeros(1)
-    class_labels = torch.flatten(torch.nonzero(class_labels))
-
-    # Get image CAMs
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--modelpath', type=str, default='/n/fs/context-scr/sunnie/COCOStuff/lr0.1_wd0_drop60/baseline/model_67.pth')
+    parser.add_argument('--img_ids', type=int, nargs='+', default=0)
+    parser.add_argument('--device', default=torch.device('cuda'))
+    parser.add_argument('--dtype', default=torch.float32)
+    arg = vars(parser.parse_args())
+    print(arg, '\n', flush=True)
+    
     normalize = T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
     transform = T.Compose([
         T.Resize(224),
@@ -77,37 +59,71 @@ def main():
     def hook_classifier_features(module, input, output):
         classifier_features.append(output)
 
-    modelpath = '/n/fs/context-scr/{}/save/stage1/stage1_4.pth'.format(dataset)
-    classifier = multilabel_classifier(torch.device('cpu'), torch.float32, modelpath=modelpath) # cuda
+    classifier = multilabel_classifier(device=arg['device'], dtype=arg['dtype'], modelpath=arg['modelpath'])
     classifier.model = classifier.model.to(device=classifier.device, dtype=classifier.dtype)
 
     classifier.model._modules['resnet'].layer4.register_forward_hook(hook_classifier_features)
     classifier_params = list(classifier.model.parameters())
     classifier_softmax_weight = classifier_params[-2].squeeze(0)
 
-    img = transform(original_img)
-    norm_img = normalize(img)
-    norm_img = norm_img.to(device=classifier.device, dtype=classifier.dtype)
-    norm_img = torch.unsqueeze(img, 0)
-    _, x = classifier.forward(norm_img)
+    for img_id in arg['img_ids']:
+        # Open image
+        img_path = '/n/fs/visualai-scr/Data/Coco/2014data/train2014/COCO_train2014_{:012d}.jpg'.format(img_id)
+        img_name = img_path.split('/')[-1][:-4]
+        if not os.path.exists(img_path):
+            print('WARNING: Could not find img {}'.format(img_id), flush=True)
+            continue
+        original_img = Image.open(img_path).convert('RGB')
 
-    CAMs = returnCAM(classifier_features[0][0].unsqueeze(0), classifier_softmax_weight, class_labels)
-    CAMs = CAMs.cpu().detach().numpy()
+        outdir = 'COCOStuff/CAMs/{}'.format(img_id)
+        if not os.path.exists(outdir):
+            os.makedirs(outdir)
+        print('Processing img {}'.format(img_id), flush=True)
 
-    # Save CAM heatmap
-    humanlabels_to_onehot = pickle.load(open('/n/fs/context-scr/{}/humanlabels_to_onehot.pkl'.format(dataset), 'rb'))
-    onehot_to_humanlabels = {v: k for k,v in humanlabels_to_onehot.items()}
+        # Get image class labels
+        img_labels = pickle.load(open('/n/fs/context-scr/COCOStuff/labels_train.pkl', 'rb'))
+        if img_path in img_labels:
+            if torch.cuda.device_count() > 0:
+                class_labels = img_labels[img_path].type('torch.cuda.ByteTensor')
+            else:
+                class_labels = img_labels[img_path].type('torch.ByteTensor')
+        else:
+            img_labels = pickle.load(open('/n/fs/context-scr/COCOStuff/labels_val.pkl', 'rb'))
+            if img_path in img_labels:
+                if torch.cuda.device_count() > 0:
+                    class_labels = img_labels[img_path].type('torch.cuda.ByteTensor')
+                else:
+                    class_labels = img_labels[img_path].type('torch.ByteTensor')
+            else:
+                print('No labels found for image {}'.format(img_path), flush=True)
+                class_labels = torch.zeros(1)
+        class_labels = torch.flatten(torch.nonzero(class_labels))
 
-    img = np.moveaxis(img.detach().cpu().numpy(), 0, -1)
-    class_labels = class_labels.cpu().detach().numpy()
-    for i in range(len(class_labels)): 
-        heatmap = get_heatmap(CAMs[i], img)
-        plt.figure()
-        plt.imshow(heatmap)
-        plt.axis('off')
-        plt.title(onehot_to_humanlabels[class_labels[i]])
-        plt.savefig('{}/{}_{}.png'.format(outdir, img_name, class_labels[i]))
-        plt.show()
+        img = transform(original_img)
+        norm_img = normalize(img)
+        norm_img = norm_img.to(device=classifier.device, dtype=classifier.dtype)
+        norm_img = norm_img.unsqueeze(0)
+        x = classifier.forward(norm_img)
+
+        CAMs = returnCAM(classifier_features[0], classifier_softmax_weight, class_labels, arg['device'])
+        CAMs = CAMs.detach().cpu().numpy()
+
+        # Save CAM heatmap
+        humanlabels_to_onehot = pickle.load(open('/n/fs/context-scr/COCOStuff/humanlabels_to_onehot.pkl', 'rb'))
+        onehot_to_humanlabels = {v: k for k,v in humanlabels_to_onehot.items()}
+
+        img = np.moveaxis(img.detach().cpu().numpy(), 0, -1)
+        class_labels = class_labels.cpu().detach().numpy()
+        for i in range(len(class_labels)): 
+            heatmap = get_heatmap(CAMs[i], img)
+            plt.figure()
+            plt.imshow(heatmap)
+            plt.axis('off')
+            plt.title(onehot_to_humanlabels[class_labels[i]])
+            humanlabel = onehot_to_humanlabels[class_labels[i]].replace(' ', '+')
+            plt.savefig('{}/{}_{}.png'.format(outdir, img_name, humanlabel))
+            plt.show()
+            plt.close()
 
 if __name__ == '__main__':
     main()

--- a/job.sh
+++ b/job.sh
@@ -15,10 +15,10 @@ source /n/fs/context-scr/context/bin/activate # for RTX3090
 #source /n/fs/visualai-scr/sunnie/basic/bin/activate # for non-RTX3090
 
 ### COCO-Stuff
-#python train.py --dataset COCOStuff --model cam --nepoch 20 --nclasses 171 \
-#  --modelpath /n/fs/context-scr/sunnie/COCOStuff/lr0.1_wd0_drop60/baseline/model_67.pth \
-#  --val_batchsize 150 --train_batchsize 200 \
-#  --outdir COCOStuff/save
+python train.py --dataset COCOStuff --model cam --nepoch 2 --nclasses 171 \
+  --modelpath /n/fs/context-scr/sunnie/COCOStuff/lr0.1_wd0_drop60/baseline/model_67.pth \
+  --val_batchsize 150 --train_batchsize 100 \
+  --outdir COCOStuff/save/cam_test
 
 #python train.py --dataset COCOStuff --model baseline --batchsize 200 \
 #    --outdir save/coco/lr0.1_wd0.00001_b200 --lr 0.1 --wd 0.00001

--- a/job.sh
+++ b/job.sh
@@ -6,7 +6,7 @@
 #SBATCH -A visualai            # specify which group of nodes to use
 #SBATCH --mem-per-cpu=4G       # memory per cpu-core (4G default)
 #SBATCH --gres=gpu:rtx_3090:1  # number of GPUs requested
-#SBATCH -t 6:00:00             # time requested in hour:minute:second
+#SBATCH -t 9:00:00             # time requested in hour:minute:second
 
 #SBATCH --mail-type=end,fail
 #SBATCH --mail-user=sharonz@princeton.edu
@@ -62,7 +62,7 @@ source /n/fs/context-scr/context/bin/activate # for RTX3090
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
 #  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_19.pth \
-#  --outdir AwA/save/featuresplit_256
+#  --outdir AwA/save2/featuresplit_256
 
 #python train.py --dataset AwA --model removecimages --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 \
@@ -88,12 +88,11 @@ source /n/fs/context-scr/context/bin/activate # for RTX3090
 #  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_19.pth \
 #  --outdir AwA/save2
 
-python train.py --dataset AwA --model splitbiased --nepoch 2 --nclasses 85 \
+python train.py --dataset AwA --model splitbiased --nepoch 40 --nclasses 85 \
   --lr 0.1 --wd 0.0 --drop 10 \
   --val_batchsize 150 --train_batchsize 200 \
   --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
   --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/splitbiased/model_38.pth \
   --outdir AwA/save2
 
 #python train.py --dataset AwA --model classbalancing --nepoch 20 --nclasses 85 \

--- a/job.sh
+++ b/job.sh
@@ -41,20 +41,20 @@ source /n/fs/context-scr/context/bin/activate # for RTX3090
 
 ### AwA
 # DONE
-#python train.py --dataset AwA --model baseline --nepoch 50 --nclasses 85 \
+#python train.py --dataset AwA --model baseline --nepoch 40 --nclasses 85 \
 #  --lr 0.1 --wd 0.0 --drop 10 \
 #  --val_batchsize 150 --train_batchsize 200 \
-#  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
+#  --labels_train /n/fs/context-scr/AwA/labels_train_80.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --outdir AwA/save2
+#  --outdir AwA/save3
 
 #python train.py --dataset AwA --model featuresplit --nepoch 20 --nclasses 85 \
-#  --lr 0.01 --wd 0.0 --drop 20 \
+#  --lr 0.01 --wd 0.0 --drop 99 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_19.pth \
-#  --outdir AwA/save2
+#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_20.pth \
+#  --outdir AwA/save3
 
 #python train.py --dataset AwA --model featuresplit --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 --split 256 \
@@ -69,55 +69,55 @@ source /n/fs/context-scr/context/bin/activate # for RTX3090
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_19.pth \
-#  --outdir AwA/save2
+#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_20.pth \
+#  --outdir AwA/save3
 
 #python train.py --dataset AwA --model removeclabels --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_19.pth \
-#  --outdir AwA/save2
+#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_20.pth \
+#  --outdir AwA/save3
 
 #python train.py --dataset AwA --model negativepenalty --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_19.pth \
-#  --outdir AwA/save2
+#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_20.pth \
+#  --outdir AwA/save3
 
-python train.py --dataset AwA --model splitbiased --nepoch 40 --nclasses 85 \
-  --lr 0.1 --wd 0.0 --drop 10 \
-  --val_batchsize 150 --train_batchsize 200 \
-  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
-  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-  --outdir AwA/save2
+#python train.py --dataset AwA --model splitbiased --nepoch 40 --nclasses 85 \
+#  --lr 0.1 --wd 0.0 --drop 10 \
+#  --val_batchsize 150 --train_batchsize 200 \
+#  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
+#  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
+#  --outdir AwA/save3
 
 #python train.py --dataset AwA --model classbalancing --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
-# --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_19.pth \
-#  --outdir AwA/save2
+#  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
+#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_20.pth \
+#  --outdir AwA/save3
 
 #python train.py --dataset AwA --model weighted --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_18.pth \
-#  --outdir AwA/save2
+#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_20.pth \
+#  --outdir AwA/save3
 
 #python train.py --dataset AwA --model attribdecorr --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 --compshare_lambda 2.0 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --pretrainedpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_19.pth \
-#  --outdir AwA/save2
+#  --pretrainedpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_20.pth \
+#  --outdir AwA/save3
 
 
 ### DeepFashion

--- a/job.sh
+++ b/job.sh
@@ -12,10 +12,10 @@ source /n/fs/context-scr/context/bin/activate # for RTX3090
 #source /n/fs/visualai-scr/sunnie/basic/bin/activate # for non-RTX3090
 
 ### COCO-Stuff
-python train.py --dataset COCOStuff --model cam --nepoch 20 --nclasses 171 \
-  --modelpath /n/fs/context-scr/sunnie/COCOStuff/lr0.1_wd0_drop60/baseline/model_99.pth \
-  --val_batchsize 150 --train_batchsize 200 \
-  --outdir COCOStuff/save
+#python train.py --dataset COCOStuff --model cam --nepoch 20 --nclasses 171 \
+#  --modelpath /n/fs/context-scr/sunnie/COCOStuff/lr0.1_wd0_drop60/baseline/model_99.pth \
+#  --val_batchsize 150 --train_batchsize 200 \
+#  --outdir COCOStuff/save
 
 #python train.py --dataset COCOStuff --model baseline --batchsize 200 \
 #    --outdir save/coco/lr0.1_wd0.00001_b200 --lr 0.1 --wd 0.00001
@@ -38,29 +38,28 @@ python train.py --dataset COCOStuff --model cam --nepoch 20 --nclasses 171 \
 
 ### AwA
 # DONE
-#python train.py --dataset AwA --model baseline --nepoch 20 --nclasses 85 \
-#  --lr 0.1 --wd 0.0 --drop 10 \
-#  --val_batchsize 150 --train_batchsize 200 \
-#  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
-#  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save/baseline_1e1to1e2_wd0/baseline/model_19.pth \
-#  --outdir AwA/save/baseline_1e1to1e2_wd0
+python train.py --dataset AwA --model baseline --nepoch 50 --nclasses 85 \
+  --lr 0.1 --wd 0.0 --drop 10 \
+  --val_batchsize 150 --train_batchsize 200 \
+  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
+  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
+  --outdir AwA/save2
 
 #python train.py --dataset AwA --model featuresplit --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save/baseline_1e1to1e2_wd0/baseline/model_19.pth \
-#  --outdir AwA/save
+#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save/baseline/model_19.pth \
+#  --outdir AwA/save/featuresplit_2
 
 #python train.py --dataset AwA --model featuresplit --nepoch 20 --nclasses 85 \
-#  --lr 0.01 --wd 0.0 --drop 20 --split 256 \
+#  --lr 0.01 --wd 0.0 --drop 20 --split 1536 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
 #  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save/baseline_1e1to1e2_wd0/baseline/model_19.pth \
-#  --outdir AwA/save/featuresplit_256
+#  --outdir AwA/save/featuresplit_1536
 
 #python train.py --dataset AwA --model removecimages --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 \

--- a/job.sh
+++ b/job.sh
@@ -5,15 +5,18 @@
 #SBATCH --exclude=node718      # exclude the node that often causes errors
 #SBATCH -A visualai            # specify which group of nodes to use
 #SBATCH --mem-per-cpu=4G       # memory per cpu-core (4G default)
-#SBATCH --gres=gpu:rtx_3090:2  # number of GPUs requested
-#SBATCH -t 36:00:00            # time requested in hour:minute:second
+#SBATCH --gres=gpu:rtx_3090:1  # number of GPUs requested
+#SBATCH -t 6:00:00             # time requested in hour:minute:second
+
+#SBATCH --mail-type=end,fail
+#SBATCH --mail-user=sharonz@princeton.edu
 
 source /n/fs/context-scr/context/bin/activate # for RTX3090
 #source /n/fs/visualai-scr/sunnie/basic/bin/activate # for non-RTX3090
 
 ### COCO-Stuff
 #python train.py --dataset COCOStuff --model cam --nepoch 20 --nclasses 171 \
-#  --modelpath /n/fs/context-scr/sunnie/COCOStuff/lr0.1_wd0_drop60/baseline/model_99.pth \
+#  --modelpath /n/fs/context-scr/sunnie/COCOStuff/lr0.1_wd0_drop60/baseline/model_67.pth \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --outdir COCOStuff/save
 
@@ -38,84 +41,84 @@ source /n/fs/context-scr/context/bin/activate # for RTX3090
 
 ### AwA
 # DONE
-python train.py --dataset AwA --model baseline --nepoch 50 --nclasses 85 \
-  --lr 0.1 --wd 0.0 --drop 10 \
-  --val_batchsize 150 --train_batchsize 200 \
-  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
-  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-  --outdir AwA/save2
+#python train.py --dataset AwA --model baseline --nepoch 50 --nclasses 85 \
+#  --lr 0.1 --wd 0.0 --drop 10 \
+#  --val_batchsize 150 --train_batchsize 200 \
+#  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
+#  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
+#  --outdir AwA/save2
 
 #python train.py --dataset AwA --model featuresplit --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save/baseline/model_19.pth \
-#  --outdir AwA/save/featuresplit_2
+#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_19.pth \
+#  --outdir AwA/save2
 
 #python train.py --dataset AwA --model featuresplit --nepoch 20 --nclasses 85 \
-#  --lr 0.01 --wd 0.0 --drop 20 --split 1536 \
+#  --lr 0.01 --wd 0.0 --drop 20 --split 256 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save/baseline_1e1to1e2_wd0/baseline/model_19.pth \
-#  --outdir AwA/save/featuresplit_1536
+#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_19.pth \
+#  --outdir AwA/save/featuresplit_256
 
 #python train.py --dataset AwA --model removecimages --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save/baseline_1e1to1e2_wd0/baseline/model_19.pth \
-#  --outdir AwA/save
+#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_19.pth \
+#  --outdir AwA/save2
 
 #python train.py --dataset AwA --model removeclabels --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save/baseline_1e1to1e2_wd0/baseline/model_19.pth \
-#  --outdir AwA/save
+#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_19.pth \
+#  --outdir AwA/save2
 
 #python train.py --dataset AwA --model negativepenalty --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save/baseline_1e1to1e2_wd0/baseline/model_19.pth \
-#  --outdir AwA/save
+#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_19.pth \
+#  --outdir AwA/save2
 
-#python train.py --dataset AwA --model splitbiased --nepoch 40 --nclasses 85 \
-#  --lr 0.1 --wd 0.0 --drop 10 \
-#  --val_batchsize 150 --train_batchsize 200 \
-#  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
-#  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --outdir AwA/save
+python train.py --dataset AwA --model splitbiased --nepoch 2 --nclasses 85 \
+  --lr 0.1 --wd 0.0 --drop 10 \
+  --val_batchsize 150 --train_batchsize 200 \
+  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
+  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
+  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/splitbiased/model_38.pth \
+  --outdir AwA/save2
 
 #python train.py --dataset AwA --model classbalancing --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
-#  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save/baseline_1e1to1e2_wd0/baseline/model_19.pth \
-#  --outdir AwA/save
+# --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
+#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_19.pth \
+#  --outdir AwA/save2
 
 #python train.py --dataset AwA --model weighted --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save/baseline_1e1to1e2_wd0/baseline/model_19.pth \
-#  --outdir AwA/save
+#  --modelpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_18.pth \
+#  --outdir AwA/save2
 
-# USE RTX GPUs
 #python train.py --dataset AwA --model attribdecorr --nepoch 20 --nclasses 85 \
 #  --lr 0.01 --wd 0.0 --drop 20 --compshare_lambda 2.0 \
 #  --val_batchsize 150 --train_batchsize 200 \
 #  --labels_train /n/fs/context-scr/AwA/labels_train.pkl \
 #  --labels_val /n/fs/context-scr/AwA/labels_train_20.pkl \
-#  --pretrainedpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save/baseline_1e1to1e2_wd0/baseline/model_19.pth \
-#  --outdir AwA/save
+#  --pretrainedpath /n/fs/context-scr/sharonz/ContextualBias/AwA/save2/baseline/model_19.pth \
+#  --outdir AwA/save2
 
 
 ### DeepFashion

--- a/train.py
+++ b/train.py
@@ -31,7 +31,7 @@ def main():
     parser.add_argument('--outdir', type=str, default='/n/fs/context-scr/COCOStuff/save')
     parser.add_argument('--labels_train', type=str, default='/n/fs/context-scr/COCOStuff/labels_train.pkl')
     parser.add_argument('--labels_val', type=str, default='/n/fs/context-scr/COCOStuff/labels_val.pkl')
-    parser.add_argument('--device', default=torch.device('cuda'))
+    parser.add_argument('--device', default=torch.device('cuda:0'))
     parser.add_argument('--dtype', default=torch.float32)
 
     arg = vars(parser.parse_args())

--- a/train.py
+++ b/train.py
@@ -35,6 +35,8 @@ def main():
     parser.add_argument('--dtype', default=torch.float32)
 
     arg = vars(parser.parse_args())
+    if arg['model'] == 'splitbiased':
+        arg['nclasses'] = arg['nclasses'] + 20
     arg['outdir'] = '{}/{}'.format(arg['outdir'], arg['model'])
     print('\n', arg, '\n')
     print('\nTraining with {} GPUs'.format(torch.cuda.device_count()))
@@ -77,7 +79,7 @@ def main():
         classifier.optimizer = torch.optim.SGD(classifier.model.parameters(), lr=arg['lr'],
                                                momentum=0.9, weight_decay=arg['wd'])
     if arg['model'] == 'splitbiased':
-        arg['nclasses'] = arg['nclasses'] + 20
+        #arg['nclasses'] = arg['nclasses'] + 20
         classifier.model.resnet.fc = torch.nn.Linear(arg['hs'], arg['nclasses'])
         classifier.nclasses = arg['nclasses']
 
@@ -121,7 +123,7 @@ def main():
     tb = SummaryWriter(log_dir='{}/runs'.format(arg['outdir']))
     start_time = time.time()
     print('\nStarted training at {}\n'.format(start_time))
-    for i in range(classifier.epoch, classifier.epoch+arg['nepoch']+1):
+    for i in range(classifier.epoch, classifier.epoch+arg['nepoch']):
 
         # Reduce learning rate from 0.1 to 0.01
         if arg['model'] != 'attribdecorr':
@@ -252,7 +254,7 @@ def main():
         exclusive_list.append(np.mean(list(exclusive_AP_dict.values()))*100)
 
         # Print out information
-        print('\nEpoch: {}'.format(i))
+        print('\nEpoch: {}'.format(i + 1))
         print('Loss: train {:.5f}, val {:.5f}'.format(np.mean(train_loss_list), np.mean(val_loss_list)))
         if arg['dataset'] == 'COCOStuff':
             print('Val mAP: all {} {:.5f}, unbiased 60 {:.5f}'.format(arg['nclasses'], mAP*100, mAP_unbiased*100))
@@ -264,10 +266,10 @@ def main():
 
     # Print best model and close tensorboard logger
     tb.close()
-    print('Best model at {} with lowest val loss {}'.format(np.argmin(loss_epoch_list), np.min(loss_epoch_list)))
-    print('Best model at {} with highest exclusive {}'.format(np.argmax(exclusive_list), np.max(exclusive_list)))
-    print('Best model at {} with highest exclusive+cooccur {}'.format(np.argmax(np.array(exclusive_list)+np.array(cooccur_list)),
-        np.max(np.array(exclusive_list)+np.array(cooccur_list))))
+    print('Best model at {} with lowest val loss {}'.format(np.argmin(loss_epoch_list) + 1, np.min(loss_epoch_list)))
+    print('Best model at {} with highest exclusive {}'.format(np.argmax(exclusive_list) + 1, np.max(exclusive_list)))
+    print('Best model at {} with highest exclusive+cooccur {}'.format(np.argmax(np.array(exclusive_list)+np.array(cooccur_list)) + 1, 
+                                                                      np.max(np.array(exclusive_list)+np.array(cooccur_list))))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
**Problem:** I tried to batch all the images together while computing CAMs, not realizing that this messes up the correspondence between co-occur image examples and the labels co-occurring in those examples. So the CAMs being computed were completely wrong.

New version: 
- Revert mostly to old code structure, but to help with memory I added an option to train with one extra GPU. This GPU is mostly reserved for computing the CAMs (although it is also used to forward images as DataParallel will be enabled). 
- If only one GPU is in use, everything is on that GPU. Smaller batch sizes will be needed (less than 200).
- If two GPUs are being used, define device 1 as the CAM computation device and device 0 as the device on which the model is stored.
- Moved some things to CPU and deleted other things to free up memory.

I also fixed the CAM visualization code to be compatible with our new CAM training methods.